### PR TITLE
change typeText to replaceText

### DIFF
--- a/app/src/androidTest/java/com/example/android/dagger/ApplicationTest.kt
+++ b/app/src/androidTest/java/com/example/android/dagger/ApplicationTest.kt
@@ -32,8 +32,8 @@ class ApplicationTest {
 
         // Should be in Registration/EnterDetails because the user is not registered
         onView(withText("Register to Dagger World!")).check(matches(isDisplayed()))
-        onView(withId(R.id.username)).perform(typeText("username"), closeSoftKeyboard())
-        onView(withId(R.id.password)).perform(typeText("password"), closeSoftKeyboard())
+        onView(withId(R.id.username)).perform(replaceText("username"), closeSoftKeyboard())
+        onView(withId(R.id.password)).perform(replaceText("password"), closeSoftKeyboard())
         onView(withId(R.id.next)).perform(click())
 
         // Registration/T&Cs


### PR DESCRIPTION
I could not pass the test at https://codelabs.developers.google.com/codelabs/android-dagger/#13.
I think that it was because I had changed the language environment to Japanese.
I think replaceText should be used instead of typeText so that it adapts to any language environment.